### PR TITLE
Add tmux auto-attach for persistent SSH sessions

### DIFF
--- a/src/backend/ssh/terminal.ts
+++ b/src/backend/ssh/terminal.ts
@@ -315,8 +315,9 @@ wss.on("connection", async (ws: WebSocket, req) => {
     };
     initialPath?: string;
     executeCommand?: string;
+    useTmux?: boolean;
   }) {
-    const { cols, rows, hostConfig, initialPath, executeCommand } = data;
+    const { cols, rows, hostConfig, initialPath, executeCommand, useTmux } = data;
     const {
       id,
       ip,
@@ -513,7 +514,12 @@ wss.on("connection", async (ws: WebSocket, req) => {
 
           setupPingInterval();
 
-          if (initialPath && initialPath.trim() !== "") {
+          // Auto-attach to tmux session if enabled
+          if (useTmux) {
+            const sessionName = `termix-${id}`;
+            const tmuxCommand = `tmux new-session -A -s ${sessionName}\n`;
+            stream.write(tmuxCommand);
+          } else if (initialPath && initialPath.trim() !== "") {
             const cdCommand = `cd "${initialPath.replace(/"/g, '\\"')}" && pwd\n`;
             stream.write(cdCommand);
           }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -189,6 +189,8 @@
     "commandsWillBeSent": "Commands will be sent to {{count}} selected terminal(s).",
     "settings": "Settings",
     "enableRightClickCopyPaste": "Enable right‑click copy/paste",
+    "enableTmuxAutoAttach": "Enable tmux auto-attach",
+    "tmuxAutoAttachDesc": "Automatically attach to persistent tmux sessions. Your sessions will survive page refreshes and can be accessed from multiple browsers.",
     "shareIdeas": "Have ideas for what should come next for ssh tools? Share them on"
   },
   "homepage": {

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -187,6 +187,8 @@
     "commandsWillBeSent": "命令将发送到 {{count}} 个选中的终端。",
     "settings": "设置",
     "enableRightClickCopyPaste": "启用右键复制/粘贴",
+    "enableTmuxAutoAttach": "启用 tmux 自动附加",
+    "tmuxAutoAttachDesc": "自动附加到持久化的 tmux 会话。您的会话将在页面刷新后保持，并可从多个浏览器访问。",
     "shareIdeas": "对 SSH 工具有什么想法？在此分享"
   },
   "homepage": {

--- a/src/ui/Desktop/Apps/Terminal/Terminal.tsx
+++ b/src/ui/Desktop/Apps/Terminal/Terminal.tsx
@@ -408,10 +408,11 @@ export const Terminal = forwardRef<any, SSHTerminalProps>(function SSHTerminal(
         }
       }, 10000);
 
+      const useTmux = getCookie("tmuxAutoAttach") === "true";
       ws.send(
         JSON.stringify({
           type: "connectToHost",
-          data: { cols, rows, hostConfig, initialPath, executeCommand },
+          data: { cols, rows, hostConfig, initialPath, executeCommand, useTmux },
         }),
       );
       terminal.onData((data) => {

--- a/src/ui/Desktop/Navigation/TopNavbar.tsx
+++ b/src/ui/Desktop/Navigation/TopNavbar.tsx
@@ -465,6 +465,25 @@ export function TopNavbar({
                   </label>
                 </div>
 
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="enable-tmux-auto-attach"
+                    onCheckedChange={(checked) =>
+                      setCookie("tmuxAutoAttach", checked.toString())
+                    }
+                    defaultChecked={getCookie("tmuxAutoAttach") === "true"}
+                  />
+                  <label
+                    htmlFor="enable-tmux-auto-attach"
+                    className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 text-white"
+                  >
+                    {t("sshTools.enableTmuxAutoAttach")}
+                  </label>
+                </div>
+                <p className="text-xs text-muted-foreground pl-6">
+                  {t("sshTools.tmuxAutoAttachDesc")}
+                </p>
+
                 <Separator className="my-4" />
 
                 <p className="pt-2 pb-2 text-sm text-gray-500">


### PR DESCRIPTION
## Summary
Add optional tmux auto-attach feature to persist SSH sessions across page refreshes and enable multi-browser session sharing.

## Implementation
- Frontend: Checkbox in SSH Tools panel
- Backend: Auto-execute `tmux new-session -A -s termix-{hostId}` on connection
- Session naming: `termix-{hostId}` for per-host isolation
- i18n: English and Chinese translations

## Benefits
- Sessions survive page refreshes
- Multi-browser/device access to same session
- Zero server-side complexity (relies on battle-tested tmux)
- Backward compatible (disabled by default)

## How to use
1. Open SSH Tools panel (🔨 button)
2. Enable "Enable tmux auto-attach" checkbox
3. Connect to any SSH host
4. Refresh page - session persists!

**Note:** Requires tmux installed on remote server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)