### PR TITLE
feat: add file manager sorting by name, date, and size

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1718,7 +1718,13 @@
     "write": "Write",
     "execute": "Execute",
     "permissionsChangedSuccessfully": "Permissions changed successfully",
-    "failedToChangePermissions": "Failed to change permissions"
+    "failedToChangePermissions": "Failed to change permissions",
+    "name": "Name",
+    "sortByName": "Name",
+    "sortByDate": "Date Modified",
+    "sortBySize": "Size",
+    "ascending": "Ascending",
+    "descending": "Descending"
   },
   "tunnel": {
     "noTunnelsConfigured": "No Tunnels Configured",

--- a/src/ui/desktop/apps/features/file-manager/FileManagerGrid.tsx
+++ b/src/ui/desktop/apps/features/file-manager/FileManagerGrid.tsx
@@ -17,6 +17,7 @@ import {
   ChevronRight,
   RefreshCw,
   ArrowUp,
+  ArrowDown,
   FileSymlink,
   Move,
   GitCompare,
@@ -95,6 +96,9 @@ interface FileManagerGridProps {
   onCancelCreate?: () => void;
   onNewFile?: () => void;
   onNewFolder?: () => void;
+  sortBy?: "name" | "modified" | "size";
+  sortOrder?: "asc" | "desc";
+  onSortChange?: (field: "name" | "modified" | "size") => void;
 }
 
 const getFileTypeColor = (file: FileItem): string => {
@@ -215,6 +219,9 @@ export function FileManagerGrid({
   onCancelCreate,
   onNewFile,
   onNewFolder,
+  sortBy,
+  sortOrder,
+  onSortChange,
 }: FileManagerGridProps) {
   const { t } = useTranslation();
   const gridRef = useRef<HTMLDivElement>(null);
@@ -1128,6 +1135,48 @@ export function FileManagerGrid({
             </div>
           ) : (
             <div className="space-y-1">
+              <div className="flex items-center gap-3 p-2 border-b border-edge text-xs text-muted-foreground font-medium sticky top-0 bg-card z-10">
+                <div className="flex-shrink-0 w-5" />
+                <div
+                  className="flex-1 min-w-0 flex items-center gap-1 cursor-pointer hover:text-foreground"
+                  onClick={() => onSortChange?.("name")}
+                >
+                  {t("fileManager.name")}
+                  {sortBy === "name" &&
+                    (sortOrder === "asc" ? (
+                      <ArrowUp className="w-3 h-3" />
+                    ) : (
+                      <ArrowDown className="w-3 h-3" />
+                    ))}
+                </div>
+                <div
+                  className="flex-shrink-0 w-32 flex items-center gap-1 cursor-pointer hover:text-foreground"
+                  onClick={() => onSortChange?.("modified")}
+                >
+                  {t("fileManager.modified")}
+                  {sortBy === "modified" &&
+                    (sortOrder === "asc" ? (
+                      <ArrowUp className="w-3 h-3" />
+                    ) : (
+                      <ArrowDown className="w-3 h-3" />
+                    ))}
+                </div>
+                <div
+                  className="flex-shrink-0 w-16 flex items-center gap-1 cursor-pointer hover:text-foreground justify-end"
+                  onClick={() => onSortChange?.("size")}
+                >
+                  {t("fileManager.size")}
+                  {sortBy === "size" &&
+                    (sortOrder === "asc" ? (
+                      <ArrowUp className="w-3 h-3" />
+                    ) : (
+                      <ArrowDown className="w-3 h-3" />
+                    ))}
+                </div>
+                <div className="flex-shrink-0 w-20 text-right">
+                  {t("fileManager.permissions")}
+                </div>
+              </div>
               {createIntent && (
                 <CreateIntentListItem
                   intent={createIntent}
@@ -1202,6 +1251,9 @@ export function FileManagerGrid({
                           → {file.linkTarget}
                         </p>
                       )}
+                    </div>
+
+                    <div className="flex-shrink-0 w-32">
                       {file.modified && (
                         <p className="text-xs text-muted-foreground">
                           {file.modified}
@@ -1209,7 +1261,7 @@ export function FileManagerGrid({
                       )}
                     </div>
 
-                    <div className="flex-shrink-0 text-right">
+                    <div className="flex-shrink-0 w-16 text-right">
                       {file.type === "file" &&
                         file.size !== undefined &&
                         file.size !== null && (


### PR DESCRIPTION
## Summary

- Add a toolbar dropdown button (ArrowUpDown icon) next to the Grid/List toggle for selecting sort field (Name / Date Modified / Size) and order (Ascending / Descending)
- Add clickable column headers in list view (Name, Modified, Size, Permissions) with arrow indicators for current sort direction
- Sort preference (field + order) persists to localStorage across sessions
- Directories-first rule is always preserved regardless of sort selection
- Extracted `modified` column from the name cell into its own fixed-width column for proper alignment with headers

## Test plan

- [ ] Grid view: click sort button → dropdown shows Name/Date/Size radio + Asc/Desc radio
- [ ] List view: column headers are visible and clickable, clicking toggles sort
- [ ] Arrow indicator shows on the currently active sort column with correct direction
- [ ] Switching between sort fields resets order to ascending
- [ ] Clicking the same sort field toggles ascending ↔ descending
- [ ] Directories always appear before files regardless of sort
- [ ] Refresh page → sort preference is restored from localStorage
- [ ] Search filter + sort combination works correctly

Fixes Termix-SSH/Support#447